### PR TITLE
Debug request info by sending a token as header

### DIFF
--- a/app/Http/Controllers/GeneralController.php
+++ b/app/Http/Controllers/GeneralController.php
@@ -56,7 +56,7 @@ class GeneralController extends Controller
             'event'             => $eventName,
             'subtitle'          => $subtitle,
             'context'           => Request::get('context'),
-            'uuid'              => Request::get('uuid'),
+            'uuid'              => isset(Request::header()['x-uuid']) ? Request::header()['x-uuid'][0] : null,
             'client_ip'         => Request::ip(),
             'client_useragent'  => Request::header()['user-agent'][0],
             'client_referer'   => isset(Request::header()['referer']) ? Request::header()['referer'][0] : null,


### PR DESCRIPTION
if you set`DEBUG_TOKEN` in `.env`, and then send it as the value to the `X-DEBUG-TOKEN` header, we'll respond with request info. could potentially be helpful by debugging. The react frontend now automatically sends the `debug-token` cookie with all requests, so you just need to use `EditThisCookie` or something to create that cookie manually:
e.g.
![image](https://user-images.githubusercontent.com/707582/28153752-0ec962c8-675c-11e7-857b-ab9ae4760657.png)

![image](https://user-images.githubusercontent.com/707582/28153771-2a23f092-675c-11e7-8be5-7676fec077c5.png)

